### PR TITLE
Add Send Text Method and Fix Module export

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 ## 📺 Library for remote control Samsung TV in your NodeJS application.
 
-_Tested with Samsung UE43NU7400_
+_Tested with Samsung UE43NU7400 and UN55NU7100_
 
 [![Build Status](https://travis-ci.org/Toxblh/samsung-tv-control.svg?branch=master)](https://travis-ci.org/Toxblh/samsung-tv-control)
 [![codecov](https://codecov.io/gh/Toxblh/samsung-tv-control/branch/master/graph/badge.svg)](https://codecov.io/gh/Toxblh/samsung-tv-control)
@@ -29,9 +29,7 @@ Also you can use the lib in your Node-RED https://github.com/Toxblh/node-red-con
 You can try [example code](example/index.js)
 
 ```js
-const Samsung = require('samsung-tv-control').default
-const { KEYS } = require('samsung-tv-control/lib/keys')
-const { APPS } = require('samsung-tv-control/lib/apps')
+const { Samsung, KEYS, APPS } = require('samsung-tv-control')
 
 const config = {
   debug: true, // Default: false

--- a/example/index-dev.js
+++ b/example/index-dev.js
@@ -1,6 +1,4 @@
-const Samsung = require('../lib/index').default
-const { KEYS } = require('../lib/keys')
-const { APPS } = require('../lib/apps')
+const { Samsung, APPS, KEYS } = require('../lib/index')
 
 const config = {
   debug: true, // Default: false
@@ -20,6 +18,7 @@ async function main() {
   console.log('$$ token:', token)
 
   await control.sendKeyPromise(KEYS.KEY_HOME)
+  await control.sendTextPromise('Text to be inserted in some focused input')
   await control.getAppsFromTVPromise()
   await control.openApp(APPS.Spotify)
   // await control.openApp(APPS.YouTube)

--- a/example/index.js
+++ b/example/index.js
@@ -29,6 +29,13 @@ control
       }
     })
 
+    // Send text to focused input on TV
+    control.sendText('Text to be inserted in some focused input', function(err, res) {
+      if (!err) {
+        console.log('# Response sendText', res)
+      }
+    })
+
     // Get all installed apps from TV
     control.getAppsFromTV((err, res) => {
       if (!err) {

--- a/src/__tests__/helpers.spec.ts
+++ b/src/__tests__/helpers.spec.ts
@@ -1,4 +1,4 @@
-import { chr, base64, getVideoId, getMsgInstalledApp, getCommandByKey, getMsgLaunchApp } from '../helpers'
+import { chr, base64, getVideoId, getMsgInstalledApp, getCommandByKey, getMsgLaunchApp, getSendTextCommand } from '../helpers'
 import { KEYS } from '../keys'
 
 describe('helpers', () => {
@@ -37,6 +37,17 @@ describe('helpers', () => {
         DataOfCmd: KEYS.KEY_0,
         Option: 'false',
         TypeOfRemote: 'SendRemoteKey'
+      }
+    })
+  })
+
+  it('should return command getSendTextCommand', () => {
+    expect(getSendTextCommand('Text to be inserted')).toEqual({
+      method: 'ms.remote.control',
+      params: {
+          Cmd: 'VGV4dCB0byBiZSBpbnNlcnRlZA==',// base64 representation of "Text to be inserted"
+          DataOfCmd: 'base64',
+          TypeOfRemote: 'SendInputString'
       }
     })
   })

--- a/src/helpers.ts
+++ b/src/helpers.ts
@@ -29,6 +29,17 @@ export function getCommandByKey(key: KEYS): Command {
   }
 }
 
+export function getSendTextCommand(text: any) {
+  return {
+    method: 'ms.remote.control',
+    params: {
+        Cmd: base64(text),
+        DataOfCmd: 'base64',
+        TypeOfRemote: 'SendInputString'
+    }
+  }
+}
+
 export function getMsgInstalledApp() {
   return {
     method: 'ms.channel.emit',

--- a/src/index.ts
+++ b/src/index.ts
@@ -6,9 +6,10 @@ import * as request from 'request'
 import * as wol from 'wake_on_lan'
 import * as WebSocket from 'ws'
 import { KEYS } from './keys'
+import { APPS } from './apps'
 import Logger from './logger'
 import { Configuration, WSData, App, Command } from './types'
-import { base64, chr, getVideoId, getMsgInstalledApp, getMsgLaunchApp, getCommandByKey } from './helpers'
+import { base64, chr, getVideoId, getMsgInstalledApp, getMsgLaunchApp, getCommandByKey, getSendTextCommand } from './helpers'
 
 class Samsung {
   private IP: string
@@ -137,6 +138,29 @@ class Samsung {
       return this._sendLegacyPromise(key)
     } else {
       return this._sendPromise(getCommandByKey(key), 'ms.channel.connect')
+    }
+  }
+
+  public sendText(
+    text: string,
+    done?: (err: Error | { code: string } | null, res: WSData | string | null) => void
+  ) {
+    this.LOGGER.log('send text', text, 'sendText')
+    if (this.PORT === 55000) {
+      this.LOGGER.error('send text not supported in legacy api', 'send text not supported', 'send text error')
+      return false
+    } else {
+      this._send(getSendTextCommand(text), done, 'ms.channel.connect')
+    }
+  }
+
+  public sendTextPromise(text: string) {
+    this.LOGGER.log('send text', text, 'sendTextPromise')
+    if (this.PORT === 55000) {
+      this.LOGGER.error('send text not supported in legacy api', 'send text not supported', 'send text error')
+      return false
+    } else {
+      return this._sendPromise(getSendTextCommand(text), 'ms.channel.connect')
     }
   }
 
@@ -491,4 +515,8 @@ class Samsung {
   }
 }
 
-export default Samsung
+export default {
+  Samsung,
+  KEYS,
+  APPS
+}


### PR DESCRIPTION
I have added a method that I used in my mobile app, for example, when user needs to perform a search the app have a search button which opens a dialog with an input and a button in this input you can use your mobile device keyboard(that is easier than use remote control) to type the text and then press the button 'send' to send the entire text to focused input on tv.

This will make search, password typing and a lot of keyboard operations much easier to be performed.

And then I decided to change the export of the module, so you can include all files you need in one line import.

![usage-example](https://user-images.githubusercontent.com/3375276/75459232-d5156080-595d-11ea-938f-d9860f65c17c.gif)
