### PR TITLE
added Disney+ app

### DIFF
--- a/src/apps.ts
+++ b/src/apps.ts
@@ -6,6 +6,7 @@ export enum APPS {
   'BBC iPlayer' = '3201601007670',
   'BT Sport' = '3201811017267',
   'CHILI' = '3201505002690',
+  'Disney+' = '3201901017640',
   'Facebook Watch' = '11091000000',
   'Gallery' = '3201710015037',
   'Google Play Movies' = '3201601007250',


### PR DESCRIPTION
see also https://github.com/Toxblh/node-red-contrib-samsung-tv-control/issues/11
result from GetApps api call: {"appId":"3201901017640","app_type":2,"icon":"/opt/share/webappservice/apps_icon/FirstScreen/3201901017640/250x250.png","is_lock":0,"name":"Disney+"}