### PR TITLE
feat: add method to update the token

### DIFF
--- a/src/samsung.ts
+++ b/src/samsung.ts
@@ -120,6 +120,11 @@ class Samsung {
       })
     })
   }
+  
+  public setToken(token: string) {
+    this.TOKEN = token
+    this.WS_URL = this._getWSUrl()
+  }
 
   public sendKey(
     key: KEYS,


### PR DESCRIPTION
When your token is invalid, methods like "sendKey" will ask permission on your TV again and send back a new token (on success) in the response (WSData).
There should be a way to update the token on your current Samsung instance when a new token was received.
(Otherwise it will keep on asking again for permission after executing a new sendKey.)