### PR TITLE
fix: Prevent opening home after getting token

### DIFF
--- a/src/samsung.ts
+++ b/src/samsung.ts
@@ -83,7 +83,7 @@ class Samsung {
       return
     }
 
-    this.sendKey(KEYS.KEY_HOME, (err, res) => {
+    this.sendKey('NON_EXISTING_KEY_GET_TOKEN', (err, res) => {
       if (err) {
         this.LOGGER.error('after sendKey', err, 'getToken')
         throw new Error('Error send Key')


### PR DESCRIPTION
In another lib I saw there is no need to actually send a key to get a token: https://github.com/Ape/samsungctl/pull/94/files.
Currently home is opening every time you accept permissions on your TV (which is not necessary).