### PR TITLE
fix(sockets): fix socket timeout error after many consecutive commands

### DIFF
--- a/src/samsung.ts
+++ b/src/samsung.ts
@@ -363,6 +363,7 @@ class Samsung {
         setTimeout(() => ws.send(JSON.stringify(command)), 1000)
       } else {
         ws.send(JSON.stringify(command))
+        setTimeout(() => ws.close(), 250);
       }
     })
 


### PR DESCRIPTION
Credit for this fix goes to the following GitHub comment: https://github.com/Toxblh/node-red-contrib-samsung-tv-control/issues/23#issuecomment-1260672299

After many consecutive commands/key presses (in my experience, around 50), the socket hangs up and raises the following error:
```
ERROR: RangeError: Invalid WebSocket frame: invalid status code 1005
    at Receiver.controlMessage (/Users/neilshweky/shabbat-cron/server/node_modules/ws/lib/receiver.js:550:18)
    at Receiver.getData (/Users/neilshweky/shabbat-cron/server/node_modules/ws/lib/receiver.js:418:42)
    at Receiver.startLoop (/Users/neilshweky/shabbat-cron/server/node_modules/ws/lib/receiver.js:143:22)
    at Receiver._write (/Users/neilshweky/shabbat-cron/server/node_modules/ws/lib/receiver.js:78:10)
    at writeOrBuffer (node:internal/streams/writable:389:12)
    at _write (node:internal/streams/writable:330:10)
    at Receiver.Writable.write (node:internal/streams/writable:334:10)
    at TLSSocket.socketOnData (/Users/neilshweky/shabbat-cron/server/node_modules/ws/lib/websocket.js:1102:35)
    at TLSSocket.emit (node:events:365:28)
    at addChunk (node:internal/streams/readable:314:12)
    at readableAddChunk (node:internal/streams/readable:289:9)
    at TLSSocket.Readable.push (node:internal/streams/readable:228:10)
    at TLSWrap.onStreamRead (node:internal/stream_base_commons:190:23) {
  code: 'WS_ERR_INVALID_CLOSE_CODE',
  [Symbol(status-code)]: 1002
}
```
And then soon after attempting the same process I get the following error:
```
          var e = new Error('ESOCKETTIMEDOUT')
                  ^

Error: ESOCKETTIMEDOUT
    at ClientRequest.<anonymous> (/Users/neilshweky/shabbat-cron/server/node_modules/request/request.js:816:19)
    at Object.onceWrapper (node:events:471:28)
    at ClientRequest.emit (node:events:365:28)
    at Socket.emitRequestTimeout (node:_http_client:761:9)
    at Object.onceWrapper (node:events:471:28)
    at Socket.emit (node:events:377:35)
    at Socket._onTimeout (node:net:475:8)
    at listOnTimeout (node:internal/timers:557:17)
    at processTimers (node:internal/timers:500:7) {
  code: 'ESOCKETTIMEDOUT',
  connect: false
}
```
This patch completely eliminates this error, and would be immensely helpful for my development going forward.

Thanks so much for your time and consideration.