### PR TITLE
fix: uncaught exception for openApp when app not installed

### DIFF
--- a/src/samsung.ts
+++ b/src/samsung.ts
@@ -228,10 +228,12 @@ class Samsung {
 
       if (!app) {
         this.LOGGER.error('This APP is not installed', { appId, app }, 'openApp getAppsFromTV')
-        throw new Error('This APP is not installed')
+        if (done) {
+          done(new Error('This APP is not installed'), null);
+        }
+      } else {
+        this._send(getMsgLaunchApp(app), done)
       }
-
-      this._send(getMsgLaunchApp(app), done)
     })
   }
 
@@ -545,11 +547,9 @@ class Samsung {
   }
 
   private _getWSUrl() {
-    return `${this.PORT === 8001 ? 'ws' : 'wss'}://${this.IP}:${
-      this.PORT
-    }/api/v2/channels/samsung.remote.control?name=${this.NAME_APP}${
-      this.TOKEN !== '' ? `&token=${this.TOKEN}` : ''
-    }`
+    return `${this.PORT === 8001 ? 'ws' : 'wss'}://${this.IP}:${this.PORT
+      }/api/v2/channels/samsung.remote.control?name=${this.NAME_APP}${this.TOKEN !== '' ? `&token=${this.TOKEN}` : ''
+      }`
   }
 }
 


### PR DESCRIPTION
When using the `openApp` function and the app passed isn't installed on the device, it throws an error but as it's thrown in the callback it causes an `uncaughtException` no matter what, with no way of catching it apart from at the process level

This PR changes that so it no longer throws the error, but passes it in the callback instead